### PR TITLE
remove the word borrow change to match

### DIFF
--- a/src/modules/components/Dashboard/Cards/TotalStaked.tsx
+++ b/src/modules/components/Dashboard/Cards/TotalStaked.tsx
@@ -25,7 +25,7 @@ const TotalStaked = () => {
   const { isOpen, onClose, onOpen } = useDisclosure()
   const { isOpen: isOpenUnstake, onClose: onCloseUnstake, onOpen: onOpenUnstake } = useDisclosure()
 
-  const { data: avaxBorrowed } = useGetAVAXAssigned(address)
+  const { data: avaxMatched } = useGetAVAXAssigned(address)
 
   const ggpPrice = useGetGGPPrice()
   const ggpStakeInAVAX = ggpPrice.data ? ggpStake * ggpPrice.data : 0
@@ -37,7 +37,7 @@ const TotalStaked = () => {
     },
     { name: 'Total GGP staked', stat: `${ggpStake.toLocaleString()} GGP` },
     { name: 'Total GGP staked converted to AVAX', stat: `${ggpStakeInAVAX.toLocaleString()} AVAX` },
-    { name: 'Borrowing', stat: `${avaxBorrowed.toLocaleString()} AVAX` },
+    { name: 'Matching', stat: `${avaxMatched.toLocaleString()} AVAX` },
   ]
 
   return (

--- a/src/modules/components/Welcome/WelcomeRewards/WelcomeRewards.tsx
+++ b/src/modules/components/Welcome/WelcomeRewards/WelcomeRewards.tsx
@@ -17,7 +17,7 @@ export default function WelcomeRewards() {
         >
           <CollatoralizationRadio
             checked={collat === '10'}
-            details="Interested in starting small? Our protocol allows for you to stake as little as 10% in GGP for collatoral to borrow the 1000 AVAX needed."
+            details="Interested in starting small? Our protocol allows for you to stake as little as 10% in GGP for collatoral to match the 1000 AVAX needed."
             radio=<Radio colorScheme={'purple'} value={'10'}>
               <div className="text-lg font-semibold text-blue-900">10% Collateralization</div>
             </Radio>

--- a/src/modules/components/Wizard/data.ts
+++ b/src/modules/components/Wizard/data.ts
@@ -24,7 +24,7 @@ export const wizardSteps: ({ defaultAvax }: { defaultAvax: any }) => WizardData[
     {
       step: 2,
       header: 'Stake GGP',
-      title: 'Borrow AVAX by staking GGP',
+      title: 'Match AVAX by staking GGP',
       image: step2pic,
       size: {
         width: 101,

--- a/src/modules/components/Wizard/steps/WizardStakeGGP.tsx
+++ b/src/modules/components/Wizard/steps/WizardStakeGGP.tsx
@@ -119,10 +119,10 @@ export const WizardStakeGGP: FunctionComponent<WizardStepTwoProps> = ({
         <StakeInput
           amount={defaultAVAXAmount}
           disabled
-          note={`Currently we only support borrowing ${DEFAULT_AVAX[chain?.id] || 0} AVAX.`}
-          title="Amount to borrow"
+          note={`Currently we only support matching ${DEFAULT_AVAX[chain?.id] || 0} AVAX.`}
+          title="Amount to Match"
           token="AVAX"
-          tooltip="Borrowed AVAX is AVAX from Liquid Stakers that the protocol will allocate to your validator node."
+          tooltip="Matched AVAX is AVAX from Liquid Stakers that the protocol will allocate to your validator node."
         />
         <StakeInput
           amount={ggpAmount}


### PR DESCRIPTION
## Changed borrow to match

- Word `borrow` is bad in crypto, we changed it to the word `match` everywhere. 