### PR TITLE
stake card buttons hotfix

### DIFF
--- a/src/hooks/useStake.ts
+++ b/src/hooks/useStake.ts
@@ -159,6 +159,26 @@ export const useGetAVAXAssigned = (stakerAddr: HexString, watch = true) => {
   }
 }
 
+// getAVAXValidatingHighWater
+export const useGetAVAXValidatingHighWater = (stakerAddr: HexString, watch = true) => {
+  const { abi, address } = useStakingContract()
+
+  const { data, error, isError, isLoading } = useContractRead({
+    address,
+    abi,
+    functionName: 'getAVAXValidatingHighWater',
+    args: [stakerAddr],
+    watch,
+  })
+
+  return {
+    data: data ? data : BigNumber.from(0),
+    isLoading,
+    isError,
+    error,
+  }
+}
+
 // getGGPPrice
 export const useGetGGPPrice = (watch = true) => {
   const { abi, address } = useOracleContract()

--- a/src/modules/components/Dashboard/Cards/Rewards/UpcomingRewardsCard.tsx
+++ b/src/modules/components/Dashboard/Cards/Rewards/UpcomingRewardsCard.tsx
@@ -16,7 +16,7 @@ import { TrophyIcon } from './TrophyIcon'
 
 import { Tooltip } from '@/common/components/Tooltip'
 import postEstimator from '@/hooks/useEstimator'
-import { useGetAVAXStake, useGetGGPStake, useRewardStartTime } from '@/hooks/useStake'
+import { useGetAVAXValidatingHighWater, useGetGGPStake, useRewardStartTime } from '@/hooks/useStake'
 import CountdownTimerNextCycle from '@/modules/components/Countdown/CountdownTimerNextCycle'
 import { colors } from '@/theme/colors'
 import { Ceres } from '@/types/ceres'
@@ -98,22 +98,23 @@ export default function UpcomingRewardsCard({
   const [ggpReward, setGgpReward] = useState(BigNumber.from(0))
 
   const { data: ggpStaked, isLoading: ggpLoading } = useGetGGPStake(address)
-  const { data: avaxStaked, isLoading: avaxLoading } = useGetAVAXStake(address)
   const { data: startTime, isLoading: startTimeLoading } = useRewardStartTime(address)
+  const { data: avaxValidatingHighWater, isLoading: avaxLoading } =
+    useGetAVAXValidatingHighWater(address)
 
   useAsyncEffect(async () => {
-    if (ggpStaked && avaxStaked) {
-      if (ggpStaked.gt(0) && avaxStaked.gt(0)) {
+    if (ggpStaked && avaxValidatingHighWater) {
+      if (ggpStaked.gt(0) && avaxValidatingHighWater.gt(0)) {
         const { apy, ggpReward } = await postEstimator({
           ggpStaked,
-          avaxStaked,
+          avaxStaked: avaxValidatingHighWater,
           walletAddress: address,
         })
         setApy(BigNumber.from(apy))
         setGgpReward(BigNumber.from(ggpReward))
       }
     }
-  }, [ggpStaked, avaxStaked])
+  }, [ggpStaked, avaxValidatingHighWater])
 
   if (ggpLoading || avaxLoading || startTimeLoading) {
     return (

--- a/src/modules/components/Modal/StakeInput.tsx
+++ b/src/modules/components/Modal/StakeInput.tsx
@@ -138,7 +138,7 @@ export const StakeInput: FunctionComponent<StakeInputModalProps> = ({
         </a>
 
         <>
-          {allowance.gte(ggpBalance) || approveStatus === 'success' ? (
+          {allowance.gte(stakeAmount) || approveStatus === 'success' ? (
             <Button
               disabled={stakeAmount.lte(0) || !stake || isLoading}
               isLoading={isLoading}

--- a/src/modules/components/Wizard/components/ApproveButton.tsx
+++ b/src/modules/components/Wizard/components/ApproveButton.tsx
@@ -45,9 +45,10 @@ const ApproveButton = ({ amount, setApproveStatus }: ApproveProps) => {
   return isConnected ? (
     <Button
       disabled={!amount || amount.lt(0) || isApproveLoading || !approve || isLoading}
-      full
       isLoading={isApproveLoading || isLoading}
       onClick={approve}
+      size="sm"
+      variant="primary"
     >
       Approve...
     </Button>


### PR DESCRIPTION
- stake card buttons appear even when a minipool is not created
- buttons are disabled but visible if wallet isn't connected
- `/countdown` page numbers are bigger again