### PR TITLE
lte instead of eq for unstake modal

### DIFF
--- a/src/modules/components/Dashboard/Cards/TotalStaked.tsx
+++ b/src/modules/components/Dashboard/Cards/TotalStaked.tsx
@@ -109,7 +109,7 @@ const TotalStaked = () => {
             <Button
               border={'1px'}
               borderColor={colors.blue[100]}
-              disabled={ggpStake.eq(0) || !address || straightRatio.eq(parseEther('1.5'))}
+              disabled={ggpStake.eq(0) || !address || straightRatio.lte(parseEther('1.5'))}
               onClick={onOpenUnstake}
               paddingX={'16px'}
               size="sm"


### PR DESCRIPTION
this should be less than or equal to 150% ratio, not exactly equal. Max unstakeable amount can only occur if user is above 150% collateral. 