### PR TITLE
Dynamic pending text for claim&restake modal

### DIFF
--- a/src/modules/components/Modal/ClaimAndRestake/ClaimAndRestakeModal.tsx
+++ b/src/modules/components/Modal/ClaimAndRestake/ClaimAndRestakeModal.tsx
@@ -103,7 +103,9 @@ export const ClaimAndRestakeModal: FunctionComponent<ClaimAndRestakeModalProps> 
               straightRatio={straightRatio}
             />
           )}
-          {currentStep === 3 && isLoading && <ClaimAndRestakeModalPending />}
+          {currentStep === 3 && isLoading && (
+            <ClaimAndRestakeModalPending restakeAmount={restakeAmount} />
+          )}
           {currentStep === 3 && isError && (
             <ClaimAndRestakeModalFailure transactionHash={claimData.hash} />
           )}

--- a/src/modules/components/Modal/ClaimAndRestake/ClaimAndRestakeModalPending.tsx
+++ b/src/modules/components/Modal/ClaimAndRestake/ClaimAndRestakeModalPending.tsx
@@ -1,13 +1,23 @@
+import { BigNumber } from 'ethers'
+
 import { Progress, Stack, Text } from '@chakra-ui/react'
 import Image from 'next/image'
 import claimAndRestake from 'public/assets/img/large_assets/claim-and-restake.svg'
 
-export const ClaimAndRestakeModalPending = () => {
+interface ClaimAndRestakeModalPendingProps {
+  restakeAmount
+}
+
+export const ClaimAndRestakeModalPending = ({
+  restakeAmount,
+}: ClaimAndRestakeModalPendingProps) => {
   return (
     <Stack align="center" gap={2} p="20">
       <Image alt="Pending" height={251} src={claimAndRestake} width={353} />
       <Text fontSize={18} fontWeight={700}>
-        Restaking Funds to Minipool
+        {restakeAmount.eq(BigNumber.from(0))
+          ? 'Sending Funds to Wallet'
+          : 'Restaking Funds to Minipool'}
       </Text>
       <Progress borderRadius={5} colorScheme="success" isIndeterminate size="sm" width="200px" />
     </Stack>


### PR DESCRIPTION
See slack thread: https://multisiglabs.slack.com/archives/C04CZSVPMA7/p1698866145026809

When restake amount is 0, we should not show text indicating that a restake is occurring. Instead, show copy that hints at sending funds to user wallet.

<img width="492" alt="image" src="https://github.com/multisig-labs/app.gogopool.com/assets/22751874/5bbd7ec3-fc65-464f-9a11-5e87781246e5">
