### PR TITLE
ceres undefined hotfix, just hide header on dashboard

### DIFF
--- a/src/modules/components/Dashboard/DashboardHeader.tsx
+++ b/src/modules/components/Dashboard/DashboardHeader.tsx
@@ -12,6 +12,9 @@ export type Props = {
 
 export default function DashboardHeader({ ceresData }: Props) {
   const { isOpen, onClose, onOpen } = useDisclosure()
+  if (ceresData === undefined) {
+    return null
+  }
   return (
     <>
       {isOpen && <RewardFaqModal onClose={onClose} />}


### PR DESCRIPTION
when ceres data returns undefined it crashes the dashboard, updated so the data needed is simply hidden instead. 